### PR TITLE
Fixing Float parse exceptions for "Unknown" bukkit versions

### DIFF
--- a/src/dev/_2lstudios/hamsterapi/HamsterAPI.java
+++ b/src/dev/_2lstudios/hamsterapi/HamsterAPI.java
@@ -34,10 +34,15 @@ public class HamsterAPI extends JavaPlugin {
 		return instance;
 	}
 
+	private static String getVersion(Server server) {
+        final String packageName = server.getClass().getPackage().getName();
+        return packageName.substring(packageName.lastIndexOf('.') + 1);
+    }
+
 	private void initialize() {
 		final Server server = getServer();
 		final Properties properties = getProperties();
-		final String bukkitVersion = server.getBukkitVersion().split("[-]")[0].replaceFirst("[.]", "");
+		final String bukkitVersion = getVersion(server).replaceAll("[^0-9]", "");
 		final int compressionThreshold = (int) properties.getOrDefault("network_compression_threshold", 256);
 
 		setInstance(this);

--- a/src/dev/_2lstudios/hamsterapi/utils/BufferIO.java
+++ b/src/dev/_2lstudios/hamsterapi/utils/BufferIO.java
@@ -18,7 +18,7 @@ public class BufferIO {
 	private final Class<?> packetDataSerializerClass, networkManagerClass, enumProtocolClass,
 			enumProtocolDirectionClass;
 	private final Inflater inflater;
-	private final float bukkitVersion;
+	private final int bukkitVersion;
 	private final int compressionThreshold;
 
 	public BufferIO(final Reflection reflection, final String bukkitVersion, final int compressionThreshold) {
@@ -27,7 +27,7 @@ public class BufferIO {
 		this.enumProtocolClass = reflection.getNMSClass("EnumProtocol");
 		this.enumProtocolDirectionClass = reflection.getNMSClass("EnumProtocolDirection");
 		this.inflater = new Inflater();
-		this.bukkitVersion = Float.valueOf(bukkitVersion);
+		this.bukkitVersion = Integer.parseInt(bukkitVersion);
 		this.compressionThreshold = compressionThreshold;
 	}
 
@@ -123,7 +123,7 @@ public class BufferIO {
 			final Class<?> packetDataClass = packetDataSerializer.getClass();
 			final int id;
 
-			if (bukkitVersion > 112.2) {
+			if (bukkitVersion > 1122) {
 				id = (int) packetDataClass.getDeclaredMethod("g").invoke(packetDataSerializer);
 			} else {
 				id = (int) packetDataClass.getDeclaredMethod("e").invoke(packetDataSerializer);


### PR DESCRIPTION
When trying to load HamsterAPI with an own Bukkit/Spigot/Paper fork, `getBukkitVersion()` will result in "Unknown" because the build number will be unknown to Bukkit. Since `server.getClass().getPackage().getName()` will work in any case and the Minecraft version number is in the path, this works perfectly fine. I also changed the comparison to an integer comparison because I was too lazy getting the same Float format, but I think it should still work since every build before 1.12.2 should have a lower integer number than 1122 and every version above should have a bigger number.